### PR TITLE
fix: deals loadstuck

### DIFF
--- a/App/ViewModels/DealsViewModel.cs
+++ b/App/ViewModels/DealsViewModel.cs
@@ -32,5 +32,4 @@ public class DealsViewModel : BaseViewModel
 
         CurrentApp.RemoveLoadingIndicator();
     }
-
 }

--- a/App/ViewModels/DealsViewModel.cs
+++ b/App/ViewModels/DealsViewModel.cs
@@ -24,10 +24,9 @@ public class DealsViewModel : BaseViewModel
     public DealsViewModel()
     {
         CurrentApp = App.Current as App;
-        UpdateDeals().GetAwaiter();
     }
 
-    private async Task UpdateDeals()
+    public async Task UpdateDeals()
     {
         Deals = new ((await CurrentApp.DataFetcher.GetDeals()).OrderByDescending(d => d.Created));
 

--- a/App/ViewModels/DealsViewModel.cs
+++ b/App/ViewModels/DealsViewModel.cs
@@ -28,7 +28,7 @@ public class DealsViewModel : BaseViewModel
 
     public async Task UpdateDeals()
     {
-        Deals = new ((await CurrentApp.DataFetcher.GetDeals()).OrderByDescending(d => d.Created));
+        Deals = new ((await CurrentApp.DataFetcher.GetDeals()).OrderBy(d => d.Expires));
 
         CurrentApp.RemoveLoadingIndicator();
     }

--- a/App/Views/DealsPage.xaml.cs
+++ b/App/Views/DealsPage.xaml.cs
@@ -5,14 +5,17 @@ namespace GamHubApp.Views;
 
 public partial class DealsPage : ContentPage
 {
-	public DealsPage(DealsViewModel vm)
+    private DealsViewModel _vm;
+
+    public DealsPage(DealsViewModel vm)
 	{
 		InitializeComponent();
-		BindingContext = vm;
+		BindingContext = _vm = vm;
 	}
     protected override void OnAppearing()
 	{
         BadgeCounterService.SetCount(0);
 		(App.Current as App).ShowLoadingIndicator();
+        _vm.UpdateDeals().GetAwaiter();
     }
 }


### PR DESCRIPTION
When navigating a second time the loading indication gets stuck

## Fix
Get the app to request an update everytime we navigate to the page as the loading indicator closes after it and we need to check for new deals each times eitherway