### PR TITLE
fix: Deal badge - badge disappearing when reopening the app

### DIFF
--- a/App/Core/AppConstant.cs
+++ b/App/Core/AppConstant.cs
@@ -33,5 +33,6 @@ namespace GamHubApp.Core
         public const string DealArticleEnable = "DEAL_ARTICLE_ENABLE";
         public const string DealPageEnable = "DEAL_PAGE_ENABLE";
         public const string OfflineLastRun = "OFFLINE_LAST";
+        public const string NewDealCount = "NEW_DEAL_COUNT";
     }
 }

--- a/App/ViewModels/AppShellViewModel.cs
+++ b/App/ViewModels/AppShellViewModel.cs
@@ -119,10 +119,16 @@ public class AppShellViewModel : BaseViewModel
         if (!(DealEnabled = Preferences.Get(AppConstant.DealPageEnable, true)))
             return;
 
+
         await dataFetcher.GetDeals();
 
+        int newDealsCount = Preferences.Get(AppConstant.NewDealCount,0) + await dataFetcher.UpdateDeals();
+
+        // Store the new value
+        Preferences.Set(AppConstant.NewDealCount, newDealsCount);
+
         // Set the deal count
-        BadgeCounterService.SetCount(await dataFetcher.UpdateDeals());
+        BadgeCounterService.SetCount(newDealsCount);
     }
 
     const string _notificationKey = "Notification";

--- a/App/Views/DealsPage.xaml.cs
+++ b/App/Views/DealsPage.xaml.cs
@@ -1,3 +1,4 @@
+using GamHubApp.Core;
 using GamHubApp.Services.UI;
 using GamHubApp.ViewModels;
 
@@ -16,7 +17,8 @@ public partial class DealsPage : ContentPage
     protected override void OnAppearing()
 	{
         BadgeCounterService.SetCount(0);
-		(App.Current as App).ShowLoadingIndicator();
+        Preferences.Set(AppConstant.NewDealCount, 0);
+        (App.Current as App).ShowLoadingIndicator();
 
         Resume();
     }


### PR DESCRIPTION
 ensure the badge stays there as long as the deals page not acknowledged