### PR TITLE
Fix: error subscription not found

### DIFF
--- a/App/ViewModels/EditFeedViewModel.cs
+++ b/App/ViewModels/EditFeedViewModel.cs
@@ -86,7 +86,7 @@ public class EditFeedViewModel : BaseViewModel
             return;
 
         // Update subcription 
-        if (_feedNotification)
+        if (_feedNotification && !(_feedNotificationPrev != _feedNotification))
             await CurrentApp.DataFetcher.SubscribeToFeed(id, token);
         else
             await CurrentApp.DataFetcher.UnsubscribeToFeed(id, token);
@@ -112,13 +112,13 @@ public class EditFeedViewModel : BaseViewModel
 
         CurrentApp = App.Current as App;
 
-        RefreshFeedSubStatus();
+        RefreshFeedSubStatus().GetAwaiter();
 
     }
     /// <summary>
     /// Manually refresh the feed subscription status
     /// </summary>
-    private async void RefreshFeedSubStatus ()
+    private async Task RefreshFeedSubStatus ()
     {
         string id = _feed.MongoID;
         string token = await SecureStorage.GetAsync(AppConstant.NotificationToken);

--- a/App/ViewModels/EditFeedViewModel.cs
+++ b/App/ViewModels/EditFeedViewModel.cs
@@ -22,6 +22,7 @@ public class EditFeedViewModel : BaseViewModel
         }
     }
 
+    private bool? _feedNotificationPrev;
     private bool _feedNotification;
     public bool FeedNotification
     {
@@ -29,6 +30,8 @@ public class EditFeedViewModel : BaseViewModel
         set
         {
             _feedNotification = value;
+            if (_feedNotificationPrev is null)
+                _feedNotificationPrev = _feedNotification;
             OnPropertyChanged(nameof(FeedNotification));
         }
     }


### PR DESCRIPTION
This issue occured when we switched the Notification of a feed on and off and saved.
It would send a useless request to the api to unsbscribed to a feed subscription that doesn't exist.

I fixed this by saving the value before editing, so I could compare it to the new value and decide whether we should send the request based on that 