### PR TITLE
hotfix: issue deal timespan doesn't display correctly when < 1 day

### DIFF
--- a/App/Helpers/Converters/TimeUntilConverter.cs
+++ b/App/Helpers/Converters/TimeUntilConverter.cs
@@ -14,13 +14,13 @@ public class TimeUntilConverter : IValueConverter
 
             if (timeremaining < TimeSpan.Zero)
                 return "expired";
-            else if (timeremaining.TotalHours < 0)
+            else if (timeremaining.TotalHours < 1)
             {
                 if (timeremaining.Minutes > 1)
                     return $"{timeremaining.Minutes} minutes"; 
                 return $"1 minute"; 
             }
-            else if (timeremaining.TotalDays < 0)
+            else if (timeremaining.TotalDays < 1)
             {
                 string hoursStr = timeremaining.Hours > 1? $"{timeremaining.Hours} hours": "1 hour";
                 string minutesStr = timeremaining.Minutes > 1? $"{timeremaining.Minutes} minutes" : "1 minute";


### PR DESCRIPTION
this is an important one to push.
All the deal that expires within less than a day get a `1 day` in front of the number of minutes remaining 