### PR TITLE
fix: deals  - consider timezone in the deals remaining

### DIFF
--- a/App/Helpers/Converters/TimeUntilConverter.cs
+++ b/App/Helpers/Converters/TimeUntilConverter.cs
@@ -10,7 +10,7 @@ public class TimeUntilConverter : IValueConverter
     {
         if (value is DateTime enddate) 
         {
-            var timeremaining = enddate - DateTime.Now;
+            var timeremaining = enddate - DateTime.UtcNow;
 
             if (timeremaining < TimeSpan.Zero)
                 return "expired";


### PR DESCRIPTION
The issue is that in the current version of the app the timespan of deals are not considering the time zone changes.

## Solution

To fix this we simply allow convert the current time to UTC then getting the time remaining