### PR TITLE
fix: ios feed deletion crash

### DIFF
--- a/App/Views/PopUps/DeleteFeedPopUp.xaml
+++ b/App/Views/PopUps/DeleteFeedPopUp.xaml
@@ -16,11 +16,11 @@
             <LinearGradientBrush StartPoint="0,0"
                                          EndPoint="1,1">
                 <GradientStop Color="#262626"
-                           Offset="0.1"/>
+                              Offset="0.1"/>
                 <GradientStop Color="{StaticResource Dark}"
-                           Offset="0.75"/>
+                              Offset="0.75"/>
                 <GradientStop Color="#0d0d0d"
-                           Offset="65.0"/>
+                              Offset="0.65"/>
             </LinearGradientBrush>
         </Border.Background>
 


### PR DESCRIPTION
Fix crashes related to the gradient of the delete feed popup.

More here: https://github.com/dotnet/macios/issues/16497