### PR TITLE
fix:  Android - Deal page disappearing after opening a popup

### DIFF
--- a/App/ViewModels/AppShellViewModel.cs
+++ b/App/ViewModels/AppShellViewModel.cs
@@ -305,6 +305,10 @@ public class AppShellViewModel : BaseViewModel
                 }); 
 
             }
+            Task.Run(async () =>
+            {
+                await UpdateDeals();
+            });
 
         }
         catch (Exception ex)


### PR DESCRIPTION
Reload the deals when opening a pop up to avoid the Deal page from disappearing. Basically forcing it to load.