### PR TITLE
Imp: deal UX - improve navigation experience

### DIFF
--- a/App/Models/Deal.cs
+++ b/App/Models/Deal.cs
@@ -36,8 +36,7 @@ public class Deal
                 {
                     await Browser.OpenAsync(Url, new BrowserLaunchOptions
                     {
-                        LaunchMode = BrowserLaunchMode.External,
-                        TitleMode = BrowserTitleMode.Default,
+                        LaunchMode = BrowserLaunchMode.External
                     });
                     if (Preferences.Get(AppConstant.DealReminderEnabled, true) && (Expires - DateTime.UtcNow).TotalHours > 5)
                         await (App.Current as App).DataFetcher.SetDealReminder(this);

--- a/App/Models/Deal.cs
+++ b/App/Models/Deal.cs
@@ -36,7 +36,7 @@ public class Deal
                 {
                     await Browser.OpenAsync(Url, new BrowserLaunchOptions
                     {
-                        LaunchMode = BrowserLaunchMode.SystemPreferred,
+                        LaunchMode = BrowserLaunchMode.External,
                         TitleMode = BrowserTitleMode.Default,
                     });
                     if (Preferences.Get(AppConstant.DealReminderEnabled, true) && (Expires - DateTime.UtcNow).TotalHours > 5)

--- a/App/ViewModels/AppShellViewModel.cs
+++ b/App/ViewModels/AppShellViewModel.cs
@@ -267,8 +267,7 @@ public class AppShellViewModel : BaseViewModel
                 MainThread.BeginInvokeOnMainThread(async () =>
                     await Browser.OpenAsync(e.Data["url"].ToString(), new BrowserLaunchOptions
                     {
-                        LaunchMode = BrowserLaunchMode.External,
-                        TitleMode = BrowserTitleMode.Default,
+                        LaunchMode = BrowserLaunchMode.External
                     }));
                 break;
             default:
@@ -311,8 +310,7 @@ public class AppShellViewModel : BaseViewModel
 
                     await Browser.OpenAsync(e.Data["url"].ToString(), new BrowserLaunchOptions
                     {
-                        LaunchMode = BrowserLaunchMode.External,
-                        TitleMode = BrowserTitleMode.Default,
+                        LaunchMode = BrowserLaunchMode.External
                     });
                 }); 
 

--- a/App/ViewModels/AppShellViewModel.cs
+++ b/App/ViewModels/AppShellViewModel.cs
@@ -267,7 +267,7 @@ public class AppShellViewModel : BaseViewModel
                 MainThread.BeginInvokeOnMainThread(async () =>
                     await Browser.OpenAsync(e.Data["url"].ToString(), new BrowserLaunchOptions
                     {
-                        LaunchMode = BrowserLaunchMode.SystemPreferred,
+                        LaunchMode = BrowserLaunchMode.External,
                         TitleMode = BrowserTitleMode.Default,
                     }));
                 break;
@@ -311,7 +311,7 @@ public class AppShellViewModel : BaseViewModel
 
                     await Browser.OpenAsync(e.Data["url"].ToString(), new BrowserLaunchOptions
                     {
-                        LaunchMode = BrowserLaunchMode.SystemPreferred,
+                        LaunchMode = BrowserLaunchMode.External,
                         TitleMode = BrowserTitleMode.Default,
                     });
                 }); 

--- a/App/ViewModels/AppShellViewModel.cs
+++ b/App/ViewModels/AppShellViewModel.cs
@@ -267,7 +267,8 @@ public class AppShellViewModel : BaseViewModel
                 MainThread.BeginInvokeOnMainThread(async () =>
                     await Browser.OpenAsync(e.Data["url"].ToString(), new BrowserLaunchOptions
                     {
-                        LaunchMode = BrowserLaunchMode.External
+                        LaunchMode = BrowserLaunchMode.SystemPreferred,
+                        TitleMode = BrowserTitleMode.Default,
                     }));
                 break;
             default:


### PR DESCRIPTION
## Changes
- Change back deal browser settings to `External` *1: was recently changed `SystemPreferred` thinking it would improve the UX but actually overtime it becomes annoying (in particular with Amazon deals) 
- Use `external` browser when navigating to a deal from a push notification

 *1 Perhaps we should allow the user to choose from the settings of the app