### PR TITLE
fix: prevent useless calls to set deal reminders

### DIFF
--- a/App/Services/Fetcher.cs
+++ b/App/Services/Fetcher.cs
@@ -955,7 +955,8 @@ public class Fetcher
     public async Task SetDealReminder(Deal deal)
     {
         if (!Fetcher.CheckFeasability() || 
-            await _firebasePushPermissions.GetAuthorizationStatusAsync() is not Plugin.FirebasePushNotifications.Model.AuthorizationStatus.Granted)
+            await _firebasePushPermissions.GetAuthorizationStatusAsync() is not Plugin.FirebasePushNotifications.Model.AuthorizationStatus.Granted ||
+            !Preferences.Get(PreferencesKeys.DealReminderEnabled, true))
             return ;
 
         Dictionary<string, string> rqHeaders = new();


### PR DESCRIPTION
The reminders are still attempted to be set even though the `NotificationEntity` is not valid.
The reason for this is because we are making the call whether or not the user enabled deal reminders.

This is not critical, as the API would just return an error and the reminder won't be set, but it's still a waste.  