### PR TITLE
fix: iOS - issues related to blank instance

### DIFF
--- a/App/App.xaml.cs
+++ b/App/App.xaml.cs
@@ -294,11 +294,11 @@ public partial class App : Application
 #endif
     }
 
-#if ANDROID
-    private void SetupInstance()
-#elif IOS
-    private async Task SetupInstance()
-#endif
+    /// <summary>
+    /// Setup the instance for a device
+    /// </summary>
+    /// <returns>a task returning the id of the instance</returns>
+    public async Task<string> SetupInstance()
     {
 
 #if IOS
@@ -308,17 +308,24 @@ public partial class App : Application
             await SecureStorage.Default.SetAsync(AppConstant.InstanceIdKey, instanceID = UIKit.UIDevice.CurrentDevice.IdentifierForVendor.ToString().ToLower().Replace("-", string.Empty).Substring(0,30));
 
         }
-#endif
 
+#if DEBUG
+        Debug.WriteLine($"Instance: {instanceID}");
+#endif
+        return
+#endif
         InstanceID =
 #if ANDROID
             Secure.GetString(Android.App.Application.Context.ContentResolver, Secure.AndroidId);
-#elif IOS
-            instanceID;
-#endif
 #if DEBUG
         Debug.WriteLine($"Instance: {InstanceID}");
 #endif
+        await SecureStorage.Default.SetAsync(AppConstant.InstanceIdKey, InstanceID);
+        return InstanceID;
+#elif IOS
+            instanceID;
+#endif
+
     }
     /// <summary>
     /// Load all the partners

--- a/App/Services/Fetcher.cs
+++ b/App/Services/Fetcher.cs
@@ -781,13 +781,20 @@ public class Fetcher
     private async Task<Dictionary<string,string>> GetHeaders()
     {
         var apiKey = Csign.GenerateApiKey();
+
+        string instanceID = await SecureStorage.Default.GetAsync(AppConstant.InstanceIdKey);
+        if (string.IsNullOrEmpty(instanceID))
+        {
+            // Reissue an instanceID
+            instanceID = await (App.Current as App).SetupInstance();
+        }
 #if DEBUG
         Debug.WriteLine($"ApiKey: {apiKey}");
 #endif
         return new Dictionary<string, string>
         {
             { "x-api-key", apiKey},
-            { "instance", await SecureStorage.Default.GetAsync(AppConstant.InstanceIdKey)},
+            { "instance", instanceID},
         };
 
     }

--- a/App/Services/Fetcher.cs
+++ b/App/Services/Fetcher.cs
@@ -1070,7 +1070,7 @@ public class Fetcher
         return Gems =  (await WebService.Get<UserGemsResponse>(controller: "gems",
                               singleUseHeaders: headers,
                               unSuccessCallback: e => _ = HandleHttpException(e)
-                               ))?.Data;
+                               ))?.Data ?? new List<Gem>();
     }
 #endif
 

--- a/App/ViewModels/AppShellViewModel.cs
+++ b/App/ViewModels/AppShellViewModel.cs
@@ -185,7 +185,19 @@ public class AppShellViewModel : BaseViewModel
     /// <returns></returns>
     public async Task UpdateGems()
     {
-        Gems = new (await dataFetcher.GetGems());
+        try
+        {
+            Gems = new(await dataFetcher.GetGems());
+
+        }
+        catch (Exception ex)
+        {
+#if DEBUG
+            Debug.WriteLine(ex);
+#elif RELEASE
+            SentrySdk.CaptureException(ex);
+#endif
+        }
 
     }
 #endif

--- a/App/ViewModels/GiveawayViewModel.cs
+++ b/App/ViewModels/GiveawayViewModel.cs
@@ -2,6 +2,9 @@
 using GamHubApp.Services;
 using GamHubApp.Views;
 using System.Collections.ObjectModel;
+#if DEBUG
+using System.Diagnostics;
+#endif
 #if IOS
 using CommunityToolkit.Mvvm.Messaging;
 using GamHubApp.Services.ChangedMessages;
@@ -76,7 +79,18 @@ public class GiveawayViewModel : BaseViewModel
     /// <returns></returns>
     public async Task UpdateGems()
     {
+        try
+        {
         Gems = new(await _fetcher.GetGems());
+        }
+        catch (Exception ex)
+        {
+#if DEBUG
+            Debug.WriteLine(ex);
+#elif RELEASE
+            SentrySdk.CaptureException(ex);
+#endif
+        }
 
     }
 


### PR DESCRIPTION
Sentry reported a common issue in with the Header is being called before the instance is getting issued.
This resulted in two issues:
- Gems balances were not tracked accurately
- the app would often throw a `System.ArgumentNullException` as we try to instantiate a new `ObservableCollection` from a null value