### PR TITLE
Chore(manifest): fix - android id declaration issue

### DIFF
--- a/App/GamHubApp.csproj
+++ b/App/GamHubApp.csproj
@@ -113,7 +113,7 @@
     <PackageReference Include="CommunityToolkit.Maui.Core" Version="10.0.0" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
     <PackageReference Include="Custard" Version="0.3.7" />
-    <PackageReference Include="Kebechet.Maui.RevenueCat.InAppBilling" Version="5.1.0" />
+    <PackageReference Include="Kebechet.Maui.RevenueCat.InAppBilling" Version="5.3.0" />
     <PackageReference Include="Plugin.FirebasePushNotifications" Version="3.0.28" />
     <PackageReference Include="Plugin.StoreReview" Version="6.2.0" />
     <PackageReference Include="Refractored.MvvmHelpers" Version="1.6.2" />

--- a/App/Platforms/Android/AndroidManifest.xml
+++ b/App/Platforms/Android/AndroidManifest.xml
@@ -1,8 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+		  xmlns:tools="http://schemas.android.com/tools">
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 	<uses-permission android:name="android.permission.INTERNET" />
 	<uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
+	<uses-permission android:name="com.google.android.gms.permission.AD_ID" tools:node="remove"/>
 	<uses-sdk
 			android:minSdkVersion="23"
 			android:targetSdkVersion="35"


### PR DESCRIPTION
Make sure we exclude `com.google.android.gms.permission.AD_ID` from the manifest as the app doesn't advertise.

This permission might be accidentally included in the RevenueCat package