### PR TITLE
hotfix: prevent crash with article navigation Samsung

### DIFF
--- a/App/Views/ArticlePage.xaml
+++ b/App/Views/ArticlePage.xaml
@@ -206,16 +206,15 @@
                       TextType="Html"
                       Grid.Row="3"
                       />
-                    <WebView Grid.Row="3"
-                        IsVisible="{OnPlatform Android='true',
-                                        iOS='false'}"
-                        x:Name="contentView"
-                        BackgroundColor="Transparent"
-                       >
-                        <WebView.Source>
-                            <HtmlWebViewSource Html="{Binding SelectedArticle.HTMLContent, Mode=OneWay}"/>
-                        </WebView.Source>
-                    </WebView>
+               <WebView Grid.Row="3"
+                       IsVisible="{OnPlatform Android='true',
+                                       iOS='false'}"
+                       x:Name="contentView"
+                       BackgroundColor="Transparent">
+                   <WebView.Source>
+                       <HtmlWebViewSource Html="{Binding SelectedArticle.HTMLContent, Mode=OneWay}"/>
+                   </WebView.Source>
+               </WebView>
 
                     <!-- Button to open to the default Browser -->
                 <Button Text="Read more"

--- a/App/Views/ArticlePage.xaml.cs
+++ b/App/Views/ArticlePage.xaml.cs
@@ -5,6 +5,9 @@ using Plugin.StoreReview;
 #if DEBUG
 using System.Diagnostics;
 #endif
+#if ANDROID
+using Android.Views;
+#endif
 
 namespace GamHubApp.Views;
 
@@ -28,12 +31,21 @@ public partial class ArticlePage : ContentPage
     public ArticlePage(Article article)
     {
         InitializeComponent();
-
+#if ANDROID
+Microsoft.Maui.Handlers.WebViewHandler.Mapper.AppendToMapping("DisableHWAccel", (handler, view) =>
+{
+    if (Android.OS.Build.Manufacturer.Contains("samsung", StringComparison.CurrentCultureIgnoreCase))
+    {
+        handler.PlatformView.SetLayerType(LayerType.Software, null);
+    }
+});
+#endif
         BindingContext = _vm = new ArticleViewModel(_article = article);
     }
 
     protected override void OnNavigatedFrom(NavigatedFromEventArgs args)
     {
+        Debug.WriteLine("Navigation stated");
         // Stop the timer
         StopTimer();
 
@@ -56,6 +68,7 @@ public partial class ArticlePage : ContentPage
         }
 
         base.OnNavigatedFrom(args);
+        Debug.WriteLine("Navigation done");
     }
     /// <summary>
     /// Stop the timer that count the time spent on reading article pages

--- a/App/Views/ArticlePage.xaml.cs
+++ b/App/Views/ArticlePage.xaml.cs
@@ -45,7 +45,6 @@ Microsoft.Maui.Handlers.WebViewHandler.Mapper.AppendToMapping("DisableHWAccel", 
 
     protected override void OnNavigatedFrom(NavigatedFromEventArgs args)
     {
-        Debug.WriteLine("Navigation stated");
         // Stop the timer
         StopTimer();
 
@@ -68,7 +67,6 @@ Microsoft.Maui.Handlers.WebViewHandler.Mapper.AppendToMapping("DisableHWAccel", 
         }
 
         base.OnNavigatedFrom(args);
-        Debug.WriteLine("Navigation done");
     }
     /// <summary>
     /// Stop the timer that count the time spent on reading article pages


### PR DESCRIPTION
A crash that has been reported by a users via support email where the app would crash when navigating to the article page on Samsung devices