### PR TITLE
hotfix: crash on deals navigation

### DIFF
--- a/App/Views/DealsPage.xaml
+++ b/App/Views/DealsPage.xaml
@@ -13,7 +13,7 @@
              x:Name="page">
     <ContentPage.Resources>
         <Style TargetType="Border"
-               x:Name="EmptyCard">
+               x:Key="EmptyCard">
             <Setter Property="BackgroundColor" Value="{StaticResource BackgroundColor}" />
             <Setter Property="StrokeShape" Value="RoundRectangle 8" />
             <Setter Property="HeightRequest" Value="220" />


### PR DESCRIPTION
basically due to the fact that `EmptyCard` was diclared with a name not a key, and `x:name` are trimmed out on Release