### PR TITLE
hotfix: Samsung - Article page | font glitches in light mode

### DIFF
--- a/App/App.xaml.cs
+++ b/App/App.xaml.cs
@@ -67,6 +67,7 @@ public partial class App : Application
 
         DataFetcher = fetc;
         Shell = shell;
+        Application.Current.UserAppTheme = AppTheme.Dark;
 
 
         InitializeComponent();


### PR DESCRIPTION
To avoid this glitch we are forcing the app to run in dark mode