### PR TITLE
fix: deal badge not displaying

### DIFF
--- a/App/Platforms/Android/Renderers/TabbarBadgeRenderer.cs
+++ b/App/Platforms/Android/Renderers/TabbarBadgeRenderer.cs
@@ -35,7 +35,7 @@ class BadgeShellBottomNavViewAppearanceTracker : ShellBottomNavViewAppearanceTra
         if (badgeDrawable is null)
         {
             // TODO: the index is hardcoded here, it would be nice to find a way to set this programatically or otherwise
-            const int dealTabbarItemIndex = 3;
+            const int dealTabbarItemIndex = 2;
 
             badgeDrawable = bottomView.GetOrCreateBadge(dealTabbarItemIndex);
             UpdateBadge(0);

--- a/App/Platforms/iOS/Renderers/TabbarBadgeRenderer.cs
+++ b/App/Platforms/iOS/Renderers/TabbarBadgeRenderer.cs
@@ -24,10 +24,10 @@ class BadgeShellTabbarAppearanceTracker : ShellTabBarAppearanceTracker
         base.UpdateLayout(controller);
 
         if (_cartTabbarItem is null
-            && controller.TabBar.Items?.Length == 4)
+            && controller.TabBar.Items?.Length == 3)
         {
             // TODO: the index is hardcoded here, it would be nice to find a way to set this programatically or otherwise
-            const int dealsTabbarItemIndex = 3;
+            const int dealsTabbarItemIndex = 2;
             _cartTabbarItem = controller.TabBar.Items[dealsTabbarItemIndex];
             if (_cartTabbarItem is not null)
             {


### PR DESCRIPTION
After we moved the bookmarks from the tab to the flyout menu the badge was not setting anymore